### PR TITLE
Add perf support 

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -55,6 +55,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
     psmisc \
     python-is-python3 \
     python3-venv \
+    python3-dev \
     qemu-user-static \
     rsync \
     ruby \
@@ -108,7 +109,9 @@ RUN apt-get install --yes --no-install-recommends \
     libnuma-dev:riscv64 \
     libpopt-dev:riscv64 \
     libssl-dev:riscv64 \
-    liburing-dev:riscv64
+    liburing-dev:riscv64 \
+    libtraceevent-dev:riscv64 \
+    pkg-config:riscv64
 
 RUN mkdir /rootfs
 

--- a/build-selftest
+++ b/build-selftest
@@ -37,6 +37,9 @@ kernel_make headers
 user_make FORMAT= \
   SKIP_TARGETS="arm64 ia64 powerpc sparc64 x86 sgx" -j $(($(nproc)-1)) -C tools/testing/selftests gen_tar
 
+# build perf
+user_make -j $(($(nproc)-1)) -C tools/perf
+
 if [[ -f /rootfs/lunar.tar ]]; then
     f=lunar.tar
 elif [[ -f /rootfs/mantic.tar ]]; then


### PR DESCRIPTION
Open Questions:

1. Should we add perf build step to build_selftest or a separate one. As it is just one line, I did not want to create a separate one.
2. Should we put the perf binary to lunar.tar or some where else like /usr/bin ??

I will update the README based on what how we build perf and run ?